### PR TITLE
Fix for 'constant::Fixnum is deprecated' error in Ruby 2.4.0

### DIFF
--- a/src/about_arrays.rb
+++ b/src/about_arrays.rb
@@ -80,5 +80,4 @@ class AboutArrays < Neo::Koan
     assert_equal __(:first), shifted_value
     assert_equal __([1, 2]), array
   end
-
 end

--- a/src/about_methods.rb
+++ b/src/about_methods.rb
@@ -15,7 +15,7 @@ class AboutMethods < Neo::Koan
     assert_equal __(5), result
   end
 
-  # (NOTE: We are Using eval below because the example code is
+  # (NOTE: We are using eval below because the example code is
   # considered to be syntactically invalid).
   def test_sometimes_missing_parentheses_are_ambiguous
     #--
@@ -31,7 +31,7 @@ class AboutMethods < Neo::Koan
     #
     #   assert_equal(5, my_global_method(2), 3)
     # or
-    #   assert_equal(5, my_global_method(2, 3))
+    #   assert_equal(5, my_global_method 2, 3))
     #
     # Rewrite the eval string to continue.
     #

--- a/src/about_nil.rb
+++ b/src/about_nil.rb
@@ -6,7 +6,7 @@ class AboutNil < Neo::Koan
   end
 
   def test_you_dont_get_null_pointer_errors_when_calling_methods_on_nil
-    # What happens when you call a method that doesn't exist.  The
+    # What happens when you call a method that doesn't exist. The
     # following begin/rescue/end code block captures the exception and
     # makes some assertions about it.
     begin
@@ -34,5 +34,4 @@ class AboutNil < Neo::Koan
     #    obj == nil
     # Why?
   end
-
 end

--- a/src/about_objects.rb
+++ b/src/about_objects.rb
@@ -21,7 +21,7 @@ class AboutObjects < Neo::Koan
 
   def test_every_object_has_an_id
     obj = Object.new
-    assert_equal __(Fixnum), obj.object_id.class
+    assert_equal __(Integer), obj.object_id.class
   end
 
   def test_every_object_has_different_id

--- a/src/about_regular_expressions.rb
+++ b/src/about_regular_expressions.rb
@@ -68,7 +68,7 @@ class AboutRegularExpressions < Neo::Koan
   end
 
   def test_slash_w_is_a_shortcut_for_a_word_character_class
-    # NOTE:  This is more like how a programmer might define a word.
+    # NOTE: This is more like how a programmer might define a word.
     assert_equal __("variable_1"), "variable_1 = 42"[/[a-zA-Z0-9_]+/]
     assert_equal __("variable_1"), "variable_1 = 42"[/\w+/]
   end


### PR DESCRIPTION
Since constant::Fixnum is deprecated in Ruby 2.4.0, about_objects.rb failed to run. Changing Fixnum to Integer fixes this.