### PR TITLE
Fix Ruby 2.7 behavior change

### DIFF
--- a/src/about_methods.rb
+++ b/src/about_methods.rb
@@ -126,11 +126,13 @@ class AboutMethods < Neo::Koan
     assert_equal __("a secret"), my_private_method
   end
 
-  def test_calling_private_methods_with_an_explicit_receiver
-    exception = assert_raise(___(NoMethodError)) do
-      self.my_private_method
+  if before_ruby_version("2.7")   # https://github.com/edgecase/ruby_koans/issues/12
+    def test_calling_private_methods_with_an_explicit_receiver
+      exception = assert_raise(___(NoMethodError)) do
+        self.my_private_method
+      end
+      assert_match /#{__("method `my_private_method'")}/, exception.message
     end
-    assert_match /#{__("method `my_private_method'")}/, exception.message
   end
 
   # ------------------------------------------------------------------

--- a/src/neo.rb
+++ b/src/neo.rb
@@ -25,6 +25,10 @@ def in_ruby_version(*versions)
   yield if versions.any? { |v| ruby_version?(v) }
 end
 
+def before_ruby_version(version)
+  Gem::Version.new(RUBY_VERSION) < Gem::Version.new(version)
+end
+
 in_ruby_version("1.8") do
   class KeyError < StandardError
   end


### PR DESCRIPTION
As described in issue #12 Ruby 2.7 changed how ruby responds to calling a private method through self. It previously threw and exception. Now it is fine.

See https://github.com/edgecase/ruby_koans/issues/12