### PR TITLE
Add support for Ruby 3

### DIFF
--- a/src/about_iteration.rb
+++ b/src/about_iteration.rb
@@ -14,7 +14,7 @@ class AboutIteration < Neo::Koan
     end
   end
 
-  in_ruby_version("1.9", "2") do
+  in_ruby_version("1.9", "2", "3") do
     def as_name(name)
       name.to_sym
     end

--- a/src/about_strings.rb
+++ b/src/about_strings.rb
@@ -159,7 +159,7 @@ EOS
     end
   end
 
-  in_ruby_version("1.9", "2") do
+  in_ruby_version("1.9", "2", "3") do
     def test_in_modern_ruby_single_characters_are_represented_by_strings
       assert_equal __('a'), ?a
       assert_equal __(false), ?a == 97

--- a/src/neo.rb
+++ b/src/neo.rb
@@ -70,7 +70,7 @@ class Object
     end
   end
 
-  in_ruby_version("1.9", "2") do
+  in_ruby_version("1.9", "2", "3") do
     public :method_missing
   end
 end

--- a/src/path_to_enlightenment.rb
+++ b/src/path_to_enlightenment.rb
@@ -12,7 +12,7 @@ require 'about_strings'
 require 'about_symbols'
 require 'about_regular_expressions'
 require 'about_methods'
-in_ruby_version("2") do
+in_ruby_version("2", "3") do
   require 'about_keyword_arguments'
 end
 require 'about_constants'


### PR DESCRIPTION
As I went through the koans to learn Ruby, I happened to be using Ruby 3.0.2.  There were a few things that didn't quite work right out of the box, so I added version 3 to the checks as I went through and encountered version issues. 