### PR TITLE
Fix name of parallel array assignement test

### DIFF
--- a/src/about_array_assignment.rb
+++ b/src/about_array_assignment.rb
@@ -24,7 +24,7 @@ class AboutArrayAssignment < Neo::Koan
     assert_equal __(["Smith","III"]), last_name
   end
 
-  def test_parallel_assignments_with_too_few_variables
+  def test_parallel_assignments_with_too_few_values
     first_name, last_name = ["Cher"]
     assert_equal __("Cher"), first_name
     assert_equal __(nil), last_name


### PR DESCRIPTION
There are two variables and just one value, so I think
`test_parallel_assignments_with_too_few_values` is a better name.