### PR TITLE
Add a koan for mandatory keyword arguments

### DIFF
--- a/src/about_keyword_arguments.rb
+++ b/src/about_keyword_arguments.rb
@@ -24,8 +24,20 @@ class AboutKeywordArguments < Neo::Koan
     assert_match(/#{__("wrong number of arguments")}/, exception.message)
   end
 
-  # THINK ABOUT IT:
-  #
-  # Keyword arguments always have a default value, making them optional to the caller
+  def method_with_mandatory_keyword_arguments(one:, two: 'two')
+    [one, two]
+  end
+
+  def test_mandatory_keyword_arguments
+    assert_equal __(['one', 'two']), method_with_mandatory_keyword_arguments(one: 'one')
+    assert_equal __([1, 2]), method_with_mandatory_keyword_arguments(two: 2, one: 1)
+  end
+
+  def test_mandatory_keyword_arguments_without_mandatory_argument
+    exception = assert_raise(___(ArgumentError)) do
+      method_with_mandatory_keyword_arguments
+    end
+    assert_match(/#{__("missing keyword: :one")}/, exception.message)
+  end
 
 end


### PR DESCRIPTION
Previously, `about_keyword_arguments.rb` asked the reader
to reflect on the fact that keyword arguments must have default
values. However, this does not seem to be true anymore in Ruby.

This PR replaces that comment with two koans that guide the
reader through validating and using a method with mandatory
keyword arguments.

This might need a version flag. I paged through some Ruby release
notes but couldn't track down the release that enabled mandatory
kwargs; I probably just missed it. It's possible since at least `2.7`.

I am quite new to Ruby myself, so please let me know if I'm missing
something here!