### PR TITLE
Replace deprecated exists call

### DIFF
--- a/src/neo.rb
+++ b/src/neo.rb
@@ -218,7 +218,7 @@ module Neo
 
     def add_progress(prog)
       @_contents = nil
-      exists = File.exists?(PROGRESS_FILE_NAME)
+      exists = File.exist?(PROGRESS_FILE_NAME)
       File.open(PROGRESS_FILE_NAME,'a+') do |f|
         f.print "#{',' if exists}#{prog}"
       end
@@ -226,7 +226,7 @@ module Neo
 
     def progress
       if @_contents.nil?
-        if File.exists?(PROGRESS_FILE_NAME)
+        if File.exist?(PROGRESS_FILE_NAME)
           File.open(PROGRESS_FILE_NAME,'r') do |f|
             @_contents = f.read.to_s.gsub(/\s/,'').split(',')
           end


### PR DESCRIPTION
This will ensure compatibility with Ruby 3.2.0, where `File.exists?` has been removed. [1]

[1] https://github.com/ruby/ruby/commit/bf97415c02b11a8949f715431aca9eeb6311add2