### PR TITLE
fix watchr path in README.rdoc

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -149,7 +149,7 @@ Install the Ruby gem (library) called +observr+ and then ask it to
     rake
     # decide to run rake automatically from now on as you edit
     gem install observr
-    observr ./koans.watchr
+    observr koans/koans.watchr
 
 == Inspiration
 


### PR DESCRIPTION
I think this is how it was intended?

Alternatively, it could be that `cd ruby_koans` is the problem, and it should instead say `cd koans` if we're intended to run rake from the subdirectory instead of the repo root. I've been running rake from the repo root though, not sure if there's a good reason not to?