### PR TITLE
Enable 'about_pattern_matching' for Ruby 3

### DIFF
--- a/src/path_to_enlightenment.rb
+++ b/src/path_to_enlightenment.rb
@@ -38,7 +38,7 @@ require 'about_to_str'
 in_ruby_version("jruby") do
   require 'about_java_interop'
 end
-in_ruby_version("2.7") do
+in_ruby_version("2.7", "3") do
   require 'about_pattern_matching'
 end
 require 'about_extra_credit'


### PR DESCRIPTION
This set of koans seems to work perfectly fine in Ruby 3, so AFAICT there's no need to gate them to 2.7.