### PR TITLE
add tip about parentheses in regex in AboutMethods

### DIFF
--- a/src/about_methods.rb
+++ b/src/about_methods.rb
@@ -39,6 +39,7 @@ class AboutMethods < Neo::Koan
 
   # NOTE: wrong number of arguments is not a SYNTAX error, but a
   # runtime error.
+  # tip: When regex contains parentheses, you must escape them with backslash.
   def test_calling_global_methods_with_wrong_number_of_arguments
     exception = assert_raise(___(ArgumentError)) do
       my_global_method


### PR DESCRIPTION
Failing myself on this koan: `test_calling_global_methods_with_wrong_number_of_arguments`, not understanding my mistake, it seems `about_methods` used to be done after `about_regular_expressions`. Few of us struggled a bit with it: https://stackoverflow.com/a/65534605.

Just adding a simple tip for future readers.