### PR TITLE
Fix assertion about the class of `Object#object_id`

### DIFF
--- a/src/about_objects.rb
+++ b/src/about_objects.rb
@@ -21,7 +21,7 @@ class AboutObjects < Neo::Koan
 
   def test_every_object_has_an_id
     obj = Object.new
-    assert_equal __(Fixnum), obj.object_id.class
+    assert obj.object_id.is_a?(__(Integer))
   end
 
   def test_every_object_has_different_id


### PR DESCRIPTION
I'm not sure whether this project is currently being maintained, but I have a few improvements I'd like to offer. I figured I'd start with this one since it's a one-line change.

In Ruby 2.4, `Fixnum` and `Bignum` were unified into `Integer` and the "bigness" of that integer became an internal implementation detail. Because the koans support some pretty old rubies, we can't make a universal assertion about the class of `Object.new.object_id`, but whatever the class, it always `is_a? Integer`.