### PR TITLE
Add solutions to about_pattern_matching.rb

### DIFF
--- a/src/about_pattern_matching.rb
+++ b/src/about_pattern_matching.rb
@@ -10,7 +10,7 @@ class AboutPatternMatching < Neo::Koan
       end
     rescue Exception => ex
       # What exception has been caught?
-      assert_equal __, ex.class
+      assert_equal __(NoMatchingPatternError), ex.class
     end
   end
 
@@ -22,7 +22,7 @@ class AboutPatternMatching < Neo::Koan
      :no_match
     end
 
-    assert_equal __, result
+    assert_equal __(:no_match), result
   end
 
   # ------------------------------------------------------------------
@@ -41,10 +41,10 @@ class AboutPatternMatching < Neo::Koan
   end
 
   def test_value_pattern
-    assert_equal __, value_pattern(0)
-    assert_equal __, value_pattern(5)
-    assert_equal __, value_pattern(100)
-    assert_equal __, value_pattern('Not a Number!')
+    assert_equal __(:match_exact_value), value_pattern(0)
+    assert_equal __(:match_in_range), value_pattern(5)
+    assert_equal __(:match_with_class), value_pattern(100)
+    assert_equal __(:no_match), value_pattern('Not a Number!')
   end
 
   # ------------------------------------------------------------------
@@ -60,7 +60,7 @@ class AboutPatternMatching < Neo::Koan
   end
 
   def test_variable_pattern_with_binding
-    assert_equal __, variable_pattern_with_binding(1)
+    assert_equal __(0), variable_pattern_with_binding(1)
   end
 
   # ------------------------------------------------------------------
@@ -77,7 +77,7 @@ class AboutPatternMatching < Neo::Koan
   end
 
   def test_variable_pattern_with_pin
-    assert_equal __, variable_pattern_with_pin(1)
+    assert_equal __(:no_match), variable_pattern_with_pin(1)
   end
 
   # ------------------------------------------------------------------
@@ -94,8 +94,8 @@ class AboutPatternMatching < Neo::Koan
   end
 
   def test_pattern_with_dropping
-    assert_equal __, pattern_with_dropping(['I will not be checked', 2])
-    assert_equal __, pattern_with_dropping(['I will not be checked', 'But I will!'])
+    assert_equal __(:match), pattern_with_dropping(['I will not be checked', 2])
+    assert_equal __(:no_match), pattern_with_dropping(['I will not be checked', 'But I will!'])
   end
 
   # ------------------------------------------------------------------
@@ -112,10 +112,10 @@ class AboutPatternMatching < Neo::Koan
   end
 
   def test_alternative_pattern
-    assert_equal __, alternative_pattern(0)
-    assert_equal __, alternative_pattern(false)
-    assert_equal __, alternative_pattern(nil)
-    assert_equal __, alternative_pattern(4)
+    assert_equal __(:match), alternative_pattern(0)
+    assert_equal __(:match), alternative_pattern(false)
+    assert_equal __(:match), alternative_pattern(nil)
+    assert_equal __(:no_match), alternative_pattern(4)
   end
 
   # ------------------------------------------------------------------
@@ -135,7 +135,7 @@ class AboutPatternMatching < Neo::Koan
   end
 
   def test_as_pattern
-    assert_equal __, as_pattern
+    assert_equal __('I was petrified'), as_pattern
   end
 
   # ------------------------------------------------------------------
@@ -163,8 +163,8 @@ class AboutPatternMatching < Neo::Koan
   end
 
   def test_array_pattern
-    assert_equal __, array_pattern(Deconstructible.new('abcd'))
-    assert_equal __, array_pattern(Deconstructible.new('123'))
+    assert_equal __(['b', 'c']), array_pattern(Deconstructible.new('abcd'))
+    assert_equal __(:no_match), array_pattern(Deconstructible.new('123'))
   end
 
   # ------------------------------------------------------------------
@@ -193,8 +193,8 @@ class AboutPatternMatching < Neo::Koan
   end
 
   def test_hash_pattern
-    assert_equal __, hash_pattern(LetterAccountant.new('aaabbc'))
-    assert_equal __, hash_pattern(LetterAccountant.new('xyz'))
+    assert_equal __([3, 2]), hash_pattern(LetterAccountant.new('aaabbc'))
+    assert_equal __([0, 0]), hash_pattern(LetterAccountant.new('xyz'))
   end
 
   # we can write it even shorter
@@ -208,8 +208,8 @@ class AboutPatternMatching < Neo::Koan
   end
 
   def test_hash_pattern_with_sugar
-    assert_equal __, hash_pattern_with_sugar(LetterAccountant.new('aaabbc'))
-    assert_equal __, hash_pattern_with_sugar(LetterAccountant.new('xyz'))
+    assert_equal __([3, 2]), hash_pattern_with_sugar(LetterAccountant.new('aaabbc'))
+    assert_equal __([0, 0]), hash_pattern_with_sugar(LetterAccountant.new('xyz'))
   end
 
 end


### PR DESCRIPTION
This Koan, added (somewhat) recently, was missing the solutions in the `src/` version.

I'm looking to work on #33 a bit, and one prerequisite (in my opinion) is that `rake run` passes. So, all Koans need solutions.