### PR TITLE
Add support for Ruby 4.0

### DIFF
--- a/src/about_iteration.rb
+++ b/src/about_iteration.rb
@@ -14,7 +14,7 @@ class AboutIteration < Neo::Koan
     end
   end
 
-  in_ruby_version("1.9", "2", "3") do
+  in_ruby_version("1.9", "2", "3", "4") do
     def as_name(name)
       name.to_sym
     end

--- a/src/about_strings.rb
+++ b/src/about_strings.rb
@@ -159,7 +159,7 @@ EOS
     end
   end
 
-  in_ruby_version("1.9", "2", "3") do
+  in_ruby_version("1.9", "2", "3", "4") do
     def test_in_modern_ruby_single_characters_are_represented_by_strings
       assert_equal __('a'), ?a
       assert_equal __(false), ?a == 97

--- a/src/neo.rb
+++ b/src/neo.rb
@@ -70,7 +70,7 @@ class Object
     end
   end
 
-  in_ruby_version("1.9", "2", "3") do
+  in_ruby_version("1.9", "2", "3", "4") do
     public :method_missing
   end
 end

--- a/src/path_to_enlightenment.rb
+++ b/src/path_to_enlightenment.rb
@@ -12,7 +12,7 @@ require 'about_objects'
 require 'about_nil'
 require 'about_hashes'
 require 'about_methods'
-in_ruby_version("2", "3") do
+in_ruby_version("2", "3", "4") do
   require 'about_keyword_arguments'
 end
 require 'about_constants'
@@ -38,7 +38,7 @@ require 'about_to_str'
 in_ruby_version("jruby") do
   require 'about_java_interop'
 end
-in_ruby_version("2.7", "3") do
+in_ruby_version("2.7", "3", "4") do
   require 'about_pattern_matching'
 end
 require 'about_extra_credit'


### PR DESCRIPTION
There's no syntax incompatibilities between 3.4 and 4.0; anything that works on 3 works on 4, too.