### PR TITLE
Fix typo in about_pattern_matching.rb

### DIFF
--- a/src/about_pattern_matching.rb
+++ b/src/about_pattern_matching.rb
@@ -169,7 +169,7 @@ class AboutPatternMatching < Neo::Koan
 
   # ------------------------------------------------------------------
 
-  # Hash pattern is quite the same as Array pattern, but it expects #deconsturct_keys(keys) method
+  # Hash pattern is quite the same as Array pattern, but it expects #deconstruct_keys(keys) method
   # It works with symbol keys for now
 
   class LetterAccountant


### PR DESCRIPTION
Fix typo in comment on line 172 of `about_pattern_matching.rb`.